### PR TITLE
Throttle: Use instance `table` field (this.table) instead of a module-level variable,…

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,8 @@ function Throttle(options) {
   this.burst = options.burst || options.rate
   this.rate = options.rate
   this.window = options.window || 1000
-  this.table = table = options.tokensTable || TokenTable({size: options.maxKeys})
+  var table = options.tokensTable || TokenTable({size: options.maxKeys})
+  this.table = table
   this.overrides = options.overrides
 
   this.getter = table.get
@@ -74,7 +75,7 @@ Throttle.prototype.rateLimit = function (key, cb) {
 
   if (!rate || !burst) return cb()
 
-  self.getter.call(table, key, function (err, bucket) {
+  self.getter.call(self.table, key, function (err, bucket) {
     if (err) {
       return cb(new Error("Unable to check token table" + err))
     }
@@ -96,7 +97,7 @@ Throttle.prototype.rateLimit = function (key, cb) {
 
     //console.log("Throttle(%s): num_tokens= %d -- throttled: %s", key, bucket.tokens, !hasCapacity)
 
-    self.putter.call(table, key, bucket, function (err) {
+    self.putter.call(self.table, key, bucket, function (err) {
       // Error here is not fatal -- we were able to determine throttle status, just not save state.
       if (err) {
         err = new Error("Error saving throttle information to table" + err)

--- a/test/index.js
+++ b/test/index.js
@@ -219,3 +219,41 @@ test("Different Token Table", function (t) {
     })
   }, 150)
 })
+
+test("Two Throttle instances", function (t) {
+  t.plan(12)
+
+  var throttle1 = Throttle({rate: 3})
+  var throttle2 = Throttle({rate: 1})
+  var i = 0
+  // Test throttle2
+  // This is so much cleaner with setImmediate... *sigh 0.8.x*
+  setTimeout(function () {
+    throttle2.rateLimit("test", function (err, limited) {
+      t.notOk(err)
+      t.notOk(limited, "throttle2 not throttled yet")
+    })
+  }, 0)
+  setTimeout(function () {
+    throttle2.rateLimit("test", function (err, limited) {
+      t.notOk(err)
+      t.ok(limited, "throttle2 should now be throttled")
+    })
+  }, 10)
+  // Make sure throttle1 is independent of throttle2
+  while (i++ < 3) {
+    // This is so much cleaner with setImmediate... *sigh 0.8.x*
+    setTimeout(function () {
+      throttle1.rateLimit("test", function (err, limited) {
+        t.notOk(err)
+        t.notOk(limited, "throttle1 not throttled yet")
+      })
+    }, 20 + i)
+  }
+  setTimeout(function () {
+    throttle1.rateLimit("test", function (err, limited) {
+      t.notOk(err)
+      t.ok(limited, "throttle1 should now be throttled")
+    })
+  }, 50)
+})


### PR DESCRIPTION
… so that all Throttle instances no longer share the table instance of the most recently created Throttle.