### PR TITLE
Allow the window option to be overridden as part of the overrides paramater

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,15 +62,18 @@ Throttle.prototype.rateLimit = function (key, cb) {
 
   var burst = self.burst
   var rate = self.rate
+  var window = self.window
 
   // Check the overrides
   if (self.overrides &&
     self.overrides[key] &&
     (self.overrides[key].burst !== undefined ||
-    self.overrides[key].rate !== undefined)) {
+    self.overrides[key].rate !== undefined ||
+    self.overrides[key].window !== undefined)) {
 
     burst = self.overrides[key].burst
     rate = self.overrides[key].rate
+    window = self.overrides[key].window
   }
 
   if (!rate || !burst) return cb()
@@ -88,7 +91,7 @@ Throttle.prototype.rateLimit = function (key, cb) {
       bucket = TokenBucket({
         capacity: burst,
         fillRate: rate,
-        window: self.window,
+        window: window,
       })
     }
 

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ Throttle.prototype.rateLimit = function (key, cb) {
 
   var burst = self.burst
   var rate = self.rate
-  var window = self.window
+  var wnd = self.window
 
   // Check the overrides
   if (self.overrides &&
@@ -73,7 +73,7 @@ Throttle.prototype.rateLimit = function (key, cb) {
 
     burst = self.overrides[key].burst
     rate = self.overrides[key].rate
-    window = self.overrides[key].window
+    wnd = self.overrides[key].window
   }
 
   if (!rate || !burst) return cb()
@@ -91,10 +91,9 @@ Throttle.prototype.rateLimit = function (key, cb) {
       bucket = TokenBucket({
         capacity: burst,
         fillRate: rate,
-        window: window,
+        window: wnd,
       })
     }
-
 
     var hasCapacity = bucket.consume(1)
 

--- a/test/index.js
+++ b/test/index.js
@@ -128,6 +128,40 @@ test("Override rate only", function (t) {
   }, 50)
 })
 
+test("Override window", function (t) {
+  t.plan(10)
+
+  var throttle = Throttle({
+    rate: 1,
+    burst: 3,
+    overrides: {
+      test: {rate: 1, burst: 3, window: 100}
+    }
+  })
+  var i = 0
+  while (i++ < 3) {
+    // This is so much cleaner with setImmediate... *sigh 0.8.x*
+    setTimeout(function () {
+      throttle.rateLimit("test", function (err, limited) {
+        t.notOk(err)
+        t.notOk(limited, "Not throttled yet")
+      })
+    }, i * 10)
+  }
+  setTimeout(function () {
+    throttle.rateLimit("test", function (err, limited) {
+      t.notOk(err)
+      t.ok(limited, "Should now be throttled.")
+    })
+  }, 50)
+  setTimeout(function () {
+    throttle.rateLimit("test", function (err, limited) {
+      t.notOk(err)
+      t.notOk(limited, "Throttle should be lifted.")
+    })
+  }, 150)
+})
+
 test("Different throttle window", function (t) {
   t.plan(10)
 


### PR DESCRIPTION
According to the documentation, it should've been possible to override the window option as well as the burst and the rate options, but it was actually ignored.

I'd appreciate if you could merge this PR, as I desperately need it for my current project.

