### PR TITLE
Add metadata to support consumers needing to back off

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ Throttle.prototype.rateLimit = function (key, cb) {
         rate: rate,
         // The number of tokens remaining
         remaining: Math.floor(bucket.tokens),
-        // The time, in seconds, when token(s) may be replenished
+        // The time, in milliseconds, when token(s) may be replenished
         reset: Math.max(0, bucket.time + wnd - Date.now())
       }
 

--- a/index.js
+++ b/index.js
@@ -71,9 +71,9 @@ Throttle.prototype.rateLimit = function (key, cb) {
     self.overrides[key].rate !== undefined ||
     self.overrides[key].window !== undefined)) {
 
-    burst = self.overrides[key].burst
-    rate = self.overrides[key].rate
-    wnd = self.overrides[key].window
+    burst = self.overrides[key].burst != null ? self.overrides[key].burst : burst
+    rate = self.overrides[key].rate != null ? self.overrides[key].rate : rate
+    wnd = self.overrides[key].window != null ? self.overrides[key].window : wnd
   }
 
   if (!rate || !burst) return cb()


### PR DESCRIPTION
4 new values are provided to the consumer:

- `limit` - the limit before throttling may occur
- `rate` - the rate of token replenishment
- `remaining` - the number of tokens remaining
- `reset` -  the time, in milliseconds, when token(s) may be replenished

These are useful for consumers to know so they be respond appropriately to avoid the throttling. e.g. in the case of a web service, these values can map to the following common response headers used for rate limiting:

- `X-RateLimit-Limit` / `RateLimit-Limit` -  `limit`
- `X-Rate-Limit-Remaining` / `Rate-Limit-Remaining` - `remaining`
- `X-RateLimit-Reset` / `RateLimit-Reset` / `Retry-After` - `reset`. This would need to be converted from millis to seconds by a consumers to be standards compliant but I left it as millis in case the added precision is required.
- `X-RateLimit-Rate` - `rate`

This allows one to reproduce similar functionality to the original restify [throttle plugin](https://github.com/restify/node-restify/blob/009f40b31612940edd196319178c574e49c85bb8/lib/plugins/throttle.js#L310-L314).

It also adds the ability to override the burst, rate, and window parameters independently in the Throttle class. Previously, these parameters could only be overridden together. Now, consumers can specify different values for each parameter when needed.

This was mainly added to ensure that we always have a valid window which is required for the `reset` metadata to function correctly.

Examples of common APIs that respond with such values for their rate limits:

- [Github](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#checking-the-status-of-your-rate-limit)
- [Vimeo](https://developer.vimeo.com/guidelines/rate-limiting#quota-usage)
- [X](https://developer.x.com/en/docs/twitter-api/rate-limits#headers-and-codes)

Related RFCs

- https://www.rfc-editor.org/rfc/rfc7231#section-7.1.3
- https://www.ietf.org/archive/id/draft-polli-ratelimit-headers-02.html